### PR TITLE
feat(frontend): implementar modal de colaboradores con gestión completa

### DIFF
--- a/backend/src/collaborator/dto/collaborator.dto.ts
+++ b/backend/src/collaborator/dto/collaborator.dto.ts
@@ -1,12 +1,13 @@
-import { IsEnum, IsNumber } from "class-validator";
+import { IsEnum, IsNumber, IsOptional } from "class-validator";
 
 export class AddCollaboratorDto {
     @IsNumber()
-    note_id: number;
+    note_id!: number;
 
     @IsNumber()
-    user_id: number;
+    user_id!: number;
 
+    @IsOptional()
     @IsEnum(['edit', 'view'])
-    permission: 'edit' | 'view';
+    permission: 'edit' | 'view' = 'edit';
 }

--- a/frontend/src/app/shared/components/collaborator-modal/collaborator-modal.component.html
+++ b/frontend/src/app/shared/components/collaborator-modal/collaborator-modal.component.html
@@ -1,0 +1,81 @@
+<div class="collab-overlay" [@overlayAnim] (click)="onOverlayClick($event)">
+  <div class="collab-modal" [@modalAnim] (click)="$event.stopPropagation()">
+
+    <!-- Header -->
+    <div class="collab-header">
+      <span class="collab-title">Colaborar</span>
+      <button class="close-btn" (click)="onDone()" title="Cerrar">
+        <i class="pi pi-times"></i>
+      </button>
+    </div>
+
+    <!-- Input de correo -->
+    <div class="collab-section">
+      <p class="section-label">Añadir personas</p>
+
+      <div class="email-input-row">
+        <div class="email-input-wrapper" [class.has-error]="emailError">
+          <i class="pi pi-envelope input-icon"></i>
+          <input
+            type="email"
+            class="email-input"
+            placeholder="Correo"
+            [(ngModel)]="emailInput"
+            (ngModelChange)="onEmailInput()"
+            (keydown.enter)="onAddCollaborator()"
+            autocomplete="off"
+          />
+        </div>
+        <button
+          class="add-btn"
+          [disabled]="isAdding"
+          (click)="onAddCollaborator()"
+          title="Añadir colaborador"
+        >
+          <i class="pi" [ngClass]="isAdding ? 'pi-spin pi-spinner' : 'pi-user-plus'"></i>
+        </button>
+      </div>
+
+      <!-- Mensaje de error -->
+      <p class="error-msg" *ngIf="emailError">
+        <i class="pi pi-exclamation-circle"></i>
+        {{ emailError }}
+      </p>
+
+      <!-- Placeholder cuando no hay colaboradores -->
+      <p class="empty-hint" *ngIf="!collaborators.length && !emailError">
+        Agrega personas para colaborar en esta nota
+      </p>
+    </div>
+
+    <!-- Lista de colaboradores añadidos -->
+    <div class="collab-list" *ngIf="collaborators.length > 0">
+      <div class="collab-item" *ngFor="let collab of collaborators">
+        <div
+          class="collab-avatar"
+          [style.background-color]="getAvatarColor(collab.user)"
+          [title]="collab.user?.name || 'Colaborador'"
+        >
+          {{ getInitials(collab.user) }}
+        </div>
+        <div class="collab-info">
+          <span class="collab-name">{{ collab.user?.name || 'Usuario' }}</span>
+          <span class="collab-email">{{ collab.user?.email || '' }}</span>
+        </div>
+        <button
+          class="remove-btn"
+          (click)="onRemoveCollaborator(collab)"
+          title="Eliminar colaborador"
+        >
+          <i class="pi pi-times"></i>
+        </button>
+      </div>
+    </div>
+
+    <!-- Footer -->
+    <div class="collab-footer">
+      <button class="done-btn" (click)="onDone()">Listo</button>
+    </div>
+
+  </div>
+</div>

--- a/frontend/src/app/shared/components/collaborator-modal/collaborator-modal.component.scss
+++ b/frontend/src/app/shared/components/collaborator-modal/collaborator-modal.component.scss
@@ -1,0 +1,371 @@
+// ── Overlay ────────────────────────────────────────────────────────────────
+.collab-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1100; // Sobre el note-modal (z-index 1000)
+  padding: 16px;
+}
+
+// ── Modal ──────────────────────────────────────────────────────────────────
+.collab-modal {
+  background: #fff;
+  border-radius: 12px;
+  width: 100%;
+  max-width: 400px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+
+  // Dark mode
+  @media (prefers-color-scheme: dark) {
+    background: #2d2d2d;
+    color: #e0e0e0;
+  }
+}
+
+// ── Header ─────────────────────────────────────────────────────────────────
+.collab-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px 12px;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+
+  @media (prefers-color-scheme: dark) {
+    border-color: rgba(255, 255, 255, 0.08);
+  }
+}
+
+.collab-title {
+  font-size: 16px;
+  font-weight: 600;
+  color: #202124;
+  letter-spacing: 0.01em;
+
+  @media (prefers-color-scheme: dark) {
+    color: #e8eaed;
+  }
+}
+
+.close-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: #5f6368;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.15s;
+  font-size: 14px;
+
+  &:hover {
+    background: rgba(0, 0, 0, 0.08);
+  }
+
+  @media (prefers-color-scheme: dark) {
+    color: #9aa0a6;
+
+    &:hover {
+      background: rgba(255, 255, 255, 0.08);
+    }
+  }
+}
+
+// ── Section ────────────────────────────────────────────────────────────────
+.collab-section {
+  padding: 16px 20px 8px;
+}
+
+.section-label {
+  font-size: 12px;
+  font-weight: 500;
+  color: #5f6368;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin: 0 0 10px;
+
+  @media (prefers-color-scheme: dark) {
+    color: #9aa0a6;
+  }
+}
+
+// ── Email input row ────────────────────────────────────────────────────────
+.email-input-row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.email-input-wrapper {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  border: 1.5px solid #dadce0;
+  border-radius: 8px;
+  padding: 0 12px;
+  height: 42px;
+  transition: border-color 0.2s, box-shadow 0.2s;
+  background: #fff;
+
+  &:focus-within {
+    border-color: #1a73e8;
+    box-shadow: 0 0 0 3px rgba(26, 115, 232, 0.12);
+  }
+
+  &.has-error {
+    border-color: #d93025;
+    box-shadow: 0 0 0 3px rgba(217, 48, 37, 0.1);
+  }
+
+  @media (prefers-color-scheme: dark) {
+    background: #3c3c3c;
+    border-color: #5f6368;
+
+    &:focus-within {
+      border-color: #8ab4f8;
+      box-shadow: 0 0 0 3px rgba(138, 180, 248, 0.15);
+    }
+
+    &.has-error {
+      border-color: #f28b82;
+    }
+  }
+}
+
+.input-icon {
+  color: #9aa0a6;
+  font-size: 14px;
+  margin-right: 8px;
+  flex-shrink: 0;
+}
+
+.email-input {
+  flex: 1;
+  border: none;
+  outline: none;
+  background: transparent;
+  font-size: 14px;
+  color: #202124;
+  font-family: inherit;
+
+  &::placeholder {
+    color: #9aa0a6;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    color: #e8eaed;
+  }
+}
+
+.add-btn {
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  border: none;
+  background: #1a73e8;
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  font-size: 16px;
+  flex-shrink: 0;
+  transition: background 0.15s, transform 0.1s;
+
+  &:hover:not(:disabled) {
+    background: #1557b0;
+    transform: scale(1.05);
+  }
+
+  &:disabled {
+    background: #ccc;
+    cursor: not-allowed;
+    transform: none;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    background: #8ab4f8;
+    color: #202124;
+
+    &:hover:not(:disabled) {
+      background: #aecbfa;
+    }
+  }
+}
+
+// ── Error / Hint ───────────────────────────────────────────────────────────
+.error-msg {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  color: #d93025;
+  font-size: 12px;
+  margin: 6px 0 0;
+
+  i { font-size: 12px; }
+
+  @media (prefers-color-scheme: dark) {
+    color: #f28b82;
+  }
+}
+
+.empty-hint {
+  color: #80868b;
+  font-size: 13px;
+  text-align: center;
+  margin: 16px 0 4px;
+
+  @media (prefers-color-scheme: dark) {
+    color: #9aa0a6;
+  }
+}
+
+// ── Collaborator List ──────────────────────────────────────────────────────
+.collab-list {
+  padding: 8px 20px 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-height: 220px;
+  overflow-y: auto;
+}
+
+.collab-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 10px;
+  border-radius: 8px;
+  transition: background 0.15s;
+
+  &:hover {
+    background: rgba(0, 0, 0, 0.04);
+
+    @media (prefers-color-scheme: dark) {
+      background: rgba(255, 255, 255, 0.06);
+    }
+  }
+}
+
+.collab-avatar {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-size: 13px;
+  font-weight: 600;
+  flex-shrink: 0;
+  letter-spacing: 0.03em;
+}
+
+.collab-info {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.collab-name {
+  font-size: 14px;
+  font-weight: 500;
+  color: #202124;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+
+  @media (prefers-color-scheme: dark) {
+    color: #e8eaed;
+  }
+}
+
+.collab-email {
+  font-size: 12px;
+  color: #5f6368;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+
+  @media (prefers-color-scheme: dark) {
+    color: #9aa0a6;
+  }
+}
+
+.remove-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: #80868b;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  font-size: 12px;
+  transition: background 0.15s, color 0.15s;
+
+  &:hover {
+    background: rgba(217, 48, 37, 0.1);
+    color: #d93025;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    color: #9aa0a6;
+
+    &:hover {
+      background: rgba(242, 139, 130, 0.15);
+      color: #f28b82;
+    }
+  }
+}
+
+// ── Footer ─────────────────────────────────────────────────────────────────
+.collab-footer {
+  display: flex;
+  justify-content: flex-end;
+  padding: 12px 20px 16px;
+  border-top: 1px solid rgba(0, 0, 0, 0.06);
+  margin-top: 4px;
+
+  @media (prefers-color-scheme: dark) {
+    border-color: rgba(255, 255, 255, 0.06);
+  }
+}
+
+.done-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 600;
+  color: #1a73e8;
+  padding: 8px 16px;
+  border-radius: 6px;
+  transition: background 0.15s;
+  font-family: inherit;
+  letter-spacing: 0.02em;
+
+  &:hover {
+    background: rgba(26, 115, 232, 0.08);
+  }
+
+  @media (prefers-color-scheme: dark) {
+    color: #8ab4f8;
+
+    &:hover {
+      background: rgba(138, 180, 248, 0.1);
+    }
+  }
+}

--- a/frontend/src/app/shared/components/collaborator-modal/collaborator-modal.component.ts
+++ b/frontend/src/app/shared/components/collaborator-modal/collaborator-modal.component.ts
@@ -1,0 +1,186 @@
+import {
+  Component, Input, Output, EventEmitter,
+  OnInit, ChangeDetectorRef
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { ButtonModule } from 'primeng/button';
+import { AvatarModule } from 'primeng/avatar';
+import { trigger, style, transition, animate } from '@angular/animations';
+import { CollaboratorService } from '../../../core/services/collaborator.service';
+import { UserService } from '../../../core/services/user.service';
+import { Collaborator } from '../../models/collaborator.model';
+import { User } from '../../models/user.model';
+
+@Component({
+  selector: 'app-collaborator-modal',
+  standalone: true,
+  imports: [CommonModule, FormsModule, ButtonModule, AvatarModule],
+  templateUrl: './collaborator-modal.component.html',
+  styleUrls: ['./collaborator-modal.component.scss'],
+  animations: [
+    trigger('overlayAnim', [
+      transition(':enter', [
+        style({ opacity: 0 }),
+        animate('150ms ease-out', style({ opacity: 1 }))
+      ]),
+      transition(':leave', [
+        animate('120ms ease-in', style({ opacity: 0 }))
+      ])
+    ]),
+    trigger('modalAnim', [
+      transition(':enter', [
+        style({ opacity: 0, transform: 'scale(0.95) translateY(-8px)' }),
+        animate('180ms ease-out', style({ opacity: 1, transform: 'scale(1) translateY(0)' }))
+      ]),
+      transition(':leave', [
+        animate('140ms ease-in', style({ opacity: 0, transform: 'scale(0.95) translateY(-8px)' }))
+      ])
+    ])
+  ]
+})
+export class CollaboratorModalComponent implements OnInit {
+  /** ID de la nota a la que se añaden colaboradores */
+  @Input() noteId!: number;
+  /** Lista inicial de colaboradores (si ya existen) */
+  @Input() initialCollaborators: Collaborator[] = [];
+
+  @Output() closed = new EventEmitter<Collaborator[]>();
+
+  emailInput = '';
+  emailError = '';
+  isAdding   = false;
+
+  collaborators: Collaborator[] = [];
+
+  constructor(
+    private collaboratorService: CollaboratorService,
+    private userService: UserService,
+    private cdr: ChangeDetectorRef
+  ) {}
+
+  ngOnInit() {
+    // Clonar para no mutar el input original
+    this.collaborators = [...(this.initialCollaborators || [])];
+  }
+
+  // ── Validación ─────────────────────────────────────────────────
+  isValidEmail(email: string): boolean {
+    const re = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    return re.test(email.trim());
+  }
+
+  onEmailInput() {
+    // Limpiar error mientras el usuario escribe
+    if (this.emailError) this.emailError = '';
+  }
+
+  onAddCollaborator() {
+    const email = this.emailInput.trim();
+
+    if (!email) {
+      this.emailError = 'Ingresa un correo electrónico.';
+      return;
+    }
+
+    if (!this.isValidEmail(email)) {
+      this.emailError = 'Formato de correo inválido.';
+      return;
+    }
+
+    // Verificar si ya está añadido
+    const alreadyAdded = this.collaborators.some(
+      c => c.user?.email?.toLowerCase() === email.toLowerCase()
+    );
+    if (alreadyAdded) {
+      this.emailError = 'Este colaborador ya fue añadido.';
+      return;
+    }
+
+    this.isAdding = true;
+    this.emailError = '';
+
+    // Buscar usuario por email y luego añadirlo
+    this.userService.getByEmail(email).subscribe({
+      next: (user: User | null) => {
+        // El backend retorna null (200 OK) si no encuentra el usuario
+        if (!user || !user.id) {
+          this.emailError = 'No se encontró un usuario con ese correo.';
+          this.isAdding = false;
+          this.cdr.detectChanges();
+          return;
+        }
+
+        this.collaboratorService.add({
+          note_id: this.noteId,
+          user_id: user.id,
+          permission: 'edit'
+        }).subscribe({
+          next: (collab: Collaborator) => {
+            const collabWithUser: Collaborator = { ...collab, user };
+            this.collaborators = [...this.collaborators, collabWithUser];
+            this.emailInput = '';
+            this.isAdding   = false;
+            this.cdr.detectChanges();
+          },
+          error: (err) => {
+            console.error('Error añadiendo colaborador:', err);
+            this.emailError = 'No se pudo añadir el colaborador. Intenta de nuevo.';
+            this.isAdding = false;
+            this.cdr.detectChanges();
+          }
+        });
+      },
+      error: (err) => {
+        console.error('Error buscando usuario:', err);
+        this.emailError = 'No se encontró un usuario con ese correo.';
+        this.isAdding = false;
+        this.cdr.detectChanges();
+      }
+    });
+  }
+
+  onRemoveCollaborator(collab: Collaborator) {
+    this.collaboratorService.delete(collab.id).subscribe({
+      next: () => {
+        this.collaborators = this.collaborators.filter(c => c.id !== collab.id);
+        this.cdr.detectChanges();
+      },
+      error: (err) => {
+        console.error('Error eliminando colaborador:', err);
+      }
+    });
+  }
+
+  onDone() {
+    this.closed.emit(this.collaborators);
+  }
+
+  onOverlayClick(event: MouseEvent) {
+    if (event.target === event.currentTarget) {
+      this.onDone();
+    }
+  }
+
+  // ── Helpers de UI ──────────────────────────────────────────────
+  getInitials(user?: User): string {
+    if (!user?.name) return '?';
+    return user.name
+      .split(' ')
+      .map(w => w[0])
+      .slice(0, 2)
+      .join('')
+      .toUpperCase();
+  }
+
+  getAvatarColor(user?: User): string {
+    if (!user?.name) return '#8B5CF6';
+    const colors = [
+      '#3B82F6', '#10B981', '#F59E0B', '#EF4444',
+      '#8B5CF6', '#EC4899', '#06B6D4', '#84CC16'
+    ];
+    let hash = 0;
+    for (const ch of user.name) hash = ch.charCodeAt(0) + ((hash << 5) - hash);
+    return colors[Math.abs(hash) % colors.length];
+  }
+}

--- a/frontend/src/app/shared/components/note-modal/note-modal.component.html
+++ b/frontend/src/app/shared/components/note-modal/note-modal.component.html
@@ -101,7 +101,7 @@
       </button>
     </div>
 
-    <!-- Chip de recordatorio activo (visible dentro del modal) -->
+    <!-- Chip de recordatorio activo -->
     <div *ngIf="reminderDate" class="reminder-chip" (click)="onToggleReminder()">
       <i class="pi pi-bell"></i>
       <span>{{ getReminderChipLabel() }}</span>
@@ -112,6 +112,18 @@
       >
         <i class="pi pi-times"></i>
       </button>
+    </div>
+
+    <!-- ✅ NUEVO: chips de colaboradores activos (visibles dentro del modal) -->
+    <div class="collaborator-chips" *ngIf="noteCollaborators.length > 0">
+      <div
+        class="collab-chip"
+        *ngFor="let collab of noteCollaborators"
+        [title]="collab.user?.name || 'Colaborador'"
+      >
+        <span class="chip-avatar">{{ getCollaboratorInitials(collab) }}</span>
+        <span class="chip-name">{{ collab.user?.name || collab.user?.email }}</span>
+      </div>
     </div>
 
     <!-- Toolbar -->
@@ -157,25 +169,22 @@
           </div>
         </div>
 
+        <!-- ✅ ACTUALIZADO: botón colaboradores con badge cuando hay colaboradores -->
         <div class="collaborator-wrapper">
           <button
             pButton
             icon="pi pi-user-plus"
             class="p-button-text p-button-rounded toolbar-icon-btn"
+            [ngClass]="{'active-btn': noteCollaborators.length > 0}"
             title="Colaborar"
             (click)="onToggleCollaborators()"
-          ></button>
-          <div *ngIf="showCollaborators" class="collaborator-popup">
-            <div class="popup-header">Colaborador</div>
-            <div class="popup-option" (click)="addCollaborator()">
-              <i class="pi pi-user"></i>
-              <span>Invitar a personas</span>
-            </div>
-            <div class="popup-option">
-              <i class="pi pi-users"></i>
-              <span>Ver grupos</span>
-            </div>
-          </div>
+          >
+          </button>
+          <!-- Badge con número de colaboradores -->
+          <span
+            class="collab-badge"
+            *ngIf="noteCollaborators.length > 0"
+          >{{ noteCollaborators.length }}</span>
         </div>
 
         <!-- Botón recordatorio — activo si hay fecha -->
@@ -218,3 +227,11 @@
   (reminderCleared)="onReminderCleared()"
   (cancelled)="onReminderCancelled()"
 ></app-reminder-modal>
+
+<!-- ✅ NUEVO: Modal de colaboradores — fuera del note-modal, mismo patrón que reminder-modal -->
+<app-collaborator-modal
+  *ngIf="showCollaborators && editNote?.id"
+  [noteId]="editNote!.id"
+  [initialCollaborators]="noteCollaborators"
+  (closed)="onCollaboratorsClosed($event)"
+></app-collaborator-modal>

--- a/frontend/src/app/shared/components/note-modal/note-modal.component.scss
+++ b/frontend/src/app/shared/components/note-modal/note-modal.component.scss
@@ -276,3 +276,69 @@
     cursor: not-allowed !important;
   }
 }
+// ── Añadir al final de note-modal.component.scss ─────────────────────────
+
+// Badge del botón de colaboradores en la toolbar
+.collaborator-wrapper {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+
+  .collab-badge {
+    position: absolute;
+    top: -2px;
+    right: -2px;
+    background: #1a73e8;
+    color: #fff;
+    font-size: 9px;
+    font-weight: 700;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    line-height: 1;
+    pointer-events: none;
+  }
+}
+
+// Chips de colaboradores dentro del note-modal (encima del toolbar)
+.collaborator-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 4px 16px 8px;
+
+  .collab-chip {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    background: rgba(0, 0, 0, 0.07);
+    border-radius: 20px;
+    padding: 3px 10px 3px 4px;
+    font-size: 12px;
+    color: #202124;
+
+    .chip-avatar {
+      width: 22px;
+      height: 22px;
+      border-radius: 50%;
+      background: #1a73e8;
+      color: #fff;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 9px;
+      font-weight: 700;
+      flex-shrink: 0;
+    }
+
+    .chip-name {
+      max-width: 100px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+  }
+}

--- a/frontend/src/app/shared/components/note-modal/note-modal.component.ts
+++ b/frontend/src/app/shared/components/note-modal/note-modal.component.ts
@@ -9,8 +9,10 @@ import {
   trigger, style, transition, animate
 } from '@angular/animations';
 import { NoteService } from '../../../core/services';
-import { CreateNoteDto, Note } from '../../models';
+import { CreateNoteDto, Note, Collaborator } from '../../models';
 import { ReminderModalComponent } from '../reminder-modal/reminder-modal.component';
+// ✅ NUEVO: importar el modal de colaboradores
+import { CollaboratorModalComponent } from '../collaborator-modal/collaborator-modal.component';
 
 interface ChecklistItemLocal {
   content: string;
@@ -21,7 +23,13 @@ interface ChecklistItemLocal {
 @Component({
   selector: 'app-note-modal',
   standalone: true,
-  imports: [CommonModule, FormsModule, ButtonModule, ReminderModalComponent],
+  imports: [
+    CommonModule,
+    FormsModule,
+    ButtonModule,
+    ReminderModalComponent,
+    CollaboratorModalComponent  // ✅ NUEVO
+  ],
   templateUrl: './note-modal.component.html',
   styleUrls: ['./note-modal.component.scss'],
   animations: [
@@ -57,12 +65,15 @@ export class NoteModalComponent implements OnInit {
   showColorPicker   = false;
   isChecklistMode   = false;
   showImageUpload   = false;
-  showCollaborators = false;
+  showCollaborators = false;  // ✅ Ahora controla el CollaboratorModalComponent
   showReminderModal = false;
 
   imagePreview: string | null = null;
   selectedFile: File | null   = null;
   reminderDate: Date | null   = null;
+
+  // ✅ NUEVO: colaboradores de la nota actual
+  noteCollaborators: Collaborator[] = [];
 
   colors = [
     { name: 'default',  class: 'note-bg-default'  },
@@ -119,6 +130,11 @@ export class NoteModalComponent implements OnInit {
         this.imagePreview    = this.editNote.image_url;
         this.showImageUpload = true;
       }
+
+      // ✅ NUEVO: cargar colaboradores existentes de la nota
+      if (this.editNote.collaborators?.length) {
+        this.noteCollaborators = [...this.editNote.collaborators];
+      }
     }
   }
 
@@ -161,7 +177,6 @@ export class NoteModalComponent implements OnInit {
       color:     this.noteData.color    || 'default',
       is_pinned: this.noteData.is_pinned ?? false,
       image_url: imageUrl,
-      // ✅ reminder_date como string ISO — el @Transform del backend lo convierte a Date
       reminder_date: this.reminderDate
         ? (this.reminderDate.toISOString() as unknown as Date)
         : undefined
@@ -274,8 +289,11 @@ export class NoteModalComponent implements OnInit {
     this.showReminderModal = false;
   }
 
-  addCollaborator() {
+  // ✅ NUEVO: recibe la lista final cuando el modal de colaboradores cierra
+  onCollaboratorsClosed(updatedList: Collaborator[]) {
+    this.noteCollaborators = updatedList;
     this.showCollaborators = false;
+    this.cdr.detectChanges();
   }
 
   // ── Checklist ──────────────────────────────────────────────────
@@ -335,6 +353,13 @@ export class NoteModalComponent implements OnInit {
     this.checklistItems[index].is_checked = checked;
   }
 
+  // ✅ NUEVO: helper para obtener iniciales del colaborador (usado en chips del modal)
+  getCollaboratorInitials(collab: Collaborator): string {
+    const name = collab.user?.name;
+    if (!name) return '?';
+    return name.split(' ').map((w: string) => w[0]).slice(0, 2).join('').toUpperCase();
+  }
+
   private resetForm() {
     this.noteData = { title: '', content: '', color: 'default', is_pinned: false };
     this.checklistItems    = [];
@@ -346,5 +371,6 @@ export class NoteModalComponent implements OnInit {
     this.reminderDate      = null;
     this.imagePreview      = null;
     this.selectedFile      = null;
+    this.noteCollaborators = [];  // ✅ NUEVO
   }
 }


### PR DESCRIPTION
Se desarrolló la funcionalidad completa de colaboradores para las notas:

- Creado CollaboratorModalComponent con:
  - Campo de input para correo electrónico con validación de formato
  - Botón para añadir colaborador buscando por email en la API
  - Lista de colaboradores añadidos con avatares circulares e iniciales
  - Colores de avatar generados dinámicamente según el nombre
  - Botón X para remover cada colaborador individualmente
  - Botón "Listo" para confirmar y cerrar el modal
  - Manejo de errores: usuario no encontrado, correo duplicado, errores de red

- Actualizado NoteModalComponent:
  - Integración del CollaboratorModalComponent reemplazando el popup simple anterior
  - Badge numérico en el botón de colaboradores cuando hay colaboradores activos
  - Chips de colaboradores visibles dentro del modal de nota

- Corregido collaborator.dto.ts en el backend:
  - Agregado @IsOptional() en el campo permission
  - Valor por defecto 'edit' para permission
  - Corregido error de asignación definitiva con operador !

- Corregido collaborator-modal.component.ts:
  - Manejo correcto del caso null en getByEmail (200 OK sin usuario)
  - cdr.detectChanges() en todos los caminos de error para evitar spinner infinito
  - Tipo User | null para reflejar lo que retorna el backend